### PR TITLE
NoAutoInstall - Wizard-Ready

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: 0xFF-BMK-webstatus
-Version: 4.0
+Version: 4.1
 Section: base
 Priority: optional
 Architecture: mipsel

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -1,11 +1,18 @@
 #!/bin/sh
-
-# Exit on error
-#set -x
+#postinst
+#change ports if needed
+#keep existing LE-certificates if exists
+#keep cronjob for renewal if existed
+#pre-calculate keys if missing
 
 echo "Preparing files and directories..."
 # create needed folder for letsencrypt initial setup files
 [ -d /config/letsencrypt/ ] || mkdir -p /config/letsencrypt/
+
+if [ ! -d "/var/log/lighttpd_custom" ]; then
+    mkdir /var/log/lighttpd_custom
+    chown www-data:www-data /var/log/lighttpd_custom
+fi
 
 # if its not already created, create cronjob for LE
 if [ ! -f "/etc/cron.monthly/letsrenew.sh" ]; then
@@ -38,61 +45,19 @@ if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 1 ]; then
     /config/scripts/port_8443.sh
 fi
 
-# hosts to check for online status
-v4iphost='8.8.8.8'
-v4dnshost='www.google.com'
-v6iphost='2001:4860:4860::8888'
-v6dnshost='www.google.com'
-
-# function to check if connectivity is given to download packages (script from vchrizz)
-onlinecheck () {
-    ping="ping -c 1 -W 1 ";
-    ping6="ping6 -c 1 -W 1 ";
-    $ping $v4iphost 2> /dev/null
-    if [[ $? == 0 ]]; then
-        # ipv4 ok
-        $ping6 $v6iphost > /dev/null
-        if [[ $? == 0 ]]; then
-            # ipv6 ok
-            $ping6 $v6dnshost > /dev/null
-            if [[ $? == 0 ]]; then
-                # ipv6dns ok
-                return 0
-            else
-                # ipv6dns not ok
-                return 1
-            fi
-        else
-            # ipv6 not ok, fallback to ipv4
-            # issue: dns resolver prefers v6 (if ipv6 is configured)
-            $ping $v4dnshost > /dev/null
-            if [[ $? == 0 ]]; then
-                # ipv4dns ok
-                return 0
-            else
-                # ipv4dns not ok
-                return 1
-            fi
-        fi
-    else
-        # ipv4 not ok
-        return 1
-    fi
-}
-
-if [ ! -d "/var/log/lighttpd_custom" ]
-then
-    mkdir /var/log/lighttpd_custom
-    chown www-data:www-data /var/log/lighttpd_custom
-fi
-
-# overwrite existing server.pem with original
-# CPO: only needed if original webserver is not running due to corrupted server.pem file
-# --> try to establish a check for such a situation?
+# reestablish server.pem with RSA key if possible
 chmod +w /etc/lighttpd/server.pem
-if [ -f "/config/letsencrypt/original_server.pem" ]; then
-  echo "Recovering original server.pem file..."
-  cp /config/letsencrypt/original_server.pem /etc/lighttpd/server.pem
+if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] &&
+   [ -f "/config/letsencrypt/domain.key" ] && [ ! $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ]
+then
+  cat /config/letsencrypt/signed.crt | tee /etc/lighttpd/server.pem
+  cat /config/letsencrypt/domain.key | tee -a /etc/lighttpd/server.pem
+elif
+  # if not, recover original server.pem if possible
+  if [ -f "/config/letsencrypt/original_server.pem" ]; then
+    echo "Recovering original server.pem file..."
+    cp /config/letsencrypt/original_server.pem /etc/lighttpd/server.pem
+  fi
 fi
 
 echo "Fire up original webserver..."
@@ -101,53 +66,20 @@ sudo /sbin/start-stop-daemon --start --quiet \
         --pidfile /var/run/lighttpd.pid \
         --exec /usr/sbin/lighttpd -- -f /etc/lighttpd/lighttpd.conf
 
-# to get the cert, you must have internet access and the custom webserver on ports 80/443
-# does not work with the stock webserver from EdgeOS due to missing rewrite-exception for /.well-known/ directory
-# CPO: improve: custom-server on port http-80, stock-server von https-443 should work as well!
-if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 0 ] && [ $(grep "http-port 80" /config/config.boot | wc -l) -eq 0 ]
-then
-        echo "Fire up custom webserver"
-        # start custom script webserver
-        sudo /sbin/start-stop-daemon --start --quiet \
-                --pidfile /var/run/lighttpd_custom.pid \
-                --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
+echo "Fire up custom webserver"
+# start custom script webserver
+sudo /sbin/start-stop-daemon --start --quiet \
+        --pidfile /var/run/lighttpd_custom.pid \
+        --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
 
-        ## calculate keys of not already there (could be done offline)
-        if [ ! -s "/config/letsencrypt/account.key" ]; then
-                echo "Caculating account-key: this could take a minute or two..."
-                openssl genrsa 4096 | tee /config/letsencrypt/account.key
-        fi
-        if [ ! -s "/config/letsencrypt/domain.key" ]; then
-                echo "Caculating domain-key: this could take a minute or two..."
-                openssl genrsa 4096 | tee /config/letsencrypt/domain.key
-        fi
-        echo "Perform online check..."
-        onlinecheck
-        if [[ $? == 0 ]]; then
-                echo "Retrieving IP and FQDN..."
-                
-                # read activated PublicIP from OLSR Daemon (should be optimized in the future)
-                if [ $(ps aux | grep olsr | grep -v grep | wc -l) -eq 0 ]; then
-                        # it works only if txtinfo Plugin is activated in the OLSR Wizard!
-                        PUBLICIP=$(echo $(curl -s -o- http://127.0.0.1:2006/interfaces | head -n3 | tail -n1 | awk {'print $5'}) | /config/custom/bin/ip2dns | awk {'print $2'} | sed -e s/dns.//)
-                else
-                        # if OLSR is not activated or not used - we get the "public" IP from the default route iface
-                        PUBLICIP=$(echo $(/sbin/ifconfig $(ip r | grep default | tail -n1 | awk {'print $5'}) | head -n2 | tail -n1 | awk {'print $2'} | sed -e s/addr://) | /config/custom/bin/ip2dns | awk {'print $2'} | sed -e s/dns.//)
-                fi
-                
-                # correctly register csr file
-                echo "Creating domain-csr..."
-                openssl req -new -sha256 -key /config/letsencrypt/domain.key -subj "/CN=$PUBLICIP" | tee /config/letsencrypt/domain.csr
-
-                # Run letsrenew.sh file for initial connect and/or renewal, doesn't matter
-                echo "Starting registration procedure..."
-                bash /config/letsencrypt/letsrenew.sh
-                echo "Done!"
-        else
-                echo "NOT ONLINE: key registration not possible"
-        fi
-else
-        echo "Custom webserver not started due to port conflicts (80/443)!"
+## calculate keys of not already there (could be done offline)
+if [ ! -f "/config/letsencrypt/account.key" ] || [ $(stat -c %s /config/letsencrypt/account.key) -eq 0 ]; then
+    echo "Calculating account-key: this could take a minute or two..."
+    openssl genrsa 4096 | tee /config/letsencrypt/account.key
+fi
+if [ ! -f "/config/letsencrypt/domain.key" ] || [ $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ]; then
+    echo "Calculating domain-key: this could take a minute or two..."
+    openssl genrsa 4096 | tee /config/letsencrypt/domain.key
 fi
 
 echo "postinst installation finished"

--- a/DEBIAN/preinst
+++ b/DEBIAN/preinst
@@ -1,7 +1,5 @@
 #!/bin/sh
-
-# Exit on error
-#set -e
+#preinstall
 
 # clean up old files from previous versions
 # old bmk-webstatus login button
@@ -57,8 +55,7 @@ fi
 # remove old custom folder with content!! (WARNING)
 # custom contains lighttpd_custom.conf, www-directory, bin/ip2dns --> will be reinstalled from package
 echo "Removing /config/custom/ ..."
-if [ -d "/config/custom/" ]
-then
+if [ -d "/config/custom/" ]; then
         rm -R /config/custom/
 fi
 echo "Removing old 0xff-restart cronjob..."

--- a/config/letsencrypt/letsrenew.sh
+++ b/config/letsencrypt/letsrenew.sh
@@ -1,4 +1,53 @@
 #!/bin/bash
+#letsrenew.sh
+#checks online state to continue
+#checks for needed files to continue
+#does nothing if no domain-registration is prepared from wizard
+
+# hosts to check for online status
+v4iphost='8.8.8.8'
+v4dnshost='www.google.com'
+v6iphost='2001:4860:4860::8888'
+v6dnshost='www.google.com'
+# function to check if connectivity is given to download packages
+onlinecheck () {
+    ping="ping -c 1 -W 1 ";
+    ping6="ping6 -c 1 -W 1 ";
+    $ping $v4iphost > /dev/null
+    if [[ $? == 0 ]]; then
+        $ping6 $v6iphost > /dev/null
+        if [[ $? == 0 ]]; then
+            $ping6 $v6dnshost > /dev/null
+            if [[ $? == 0 ]]; then
+                return 0
+            else
+                return 1
+            fi
+        else
+            $ping $v4dnshost > /dev/null
+            if [[ $? == 0 ]]; then
+                return 0
+            else
+                return 1
+            fi
+        fi
+    else
+        return 1
+    fi
+}
+
+# needed files available for renewal or initial creation?
+if [ ! $((onlinecheck)) == 0 ] ||
+   [ ! -f "/config/letsencrypt/domain.csr" ] ||
+   [ $(stat -c %s /config/letsencrypt/domain.csr) -eq 0 ] ||
+   [ ! -f "/config/letsencrypt/domain.key" ] ||
+   [ $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ] ||
+   [ ! -f "/config/letsencrypt/account.key" ] ||
+   [ $(stat -c %s /config/letsencrypt/account.key) -eq 0 ] ||
+   [ ! -d "/config/custom/www/.well-known/acme-challenge/" ]
+then
+  echo "error: offline, missing or empty files, or challenge-directory!"
+else
 
 # Opening up firewall on port 80
 CHAIN=$( iptables -L | awk '/^Chain WAN/ && /LOCAL/ {print $2;}' )
@@ -11,7 +60,9 @@ python /config/letsencrypt/acme_tiny.py --account-key /config/letsencrypt/accoun
 iptables -D $CHAIN 1
 
 # Copying files to lighttpd directory on success only (file domain.key is not empty)
-if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ]; then
+if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] &&
+   [ -f "/config/letsencrypt/domain.key" ] && [ ! $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ]
+then
   cat /config/letsencrypt/signed.crt | tee /etc/lighttpd/server.pem
   cat /config/letsencrypt/domain.key | tee -a /etc/lighttpd/server.pem
 
@@ -36,4 +87,6 @@ if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencry
           --pidfile /var/run/lighttpd_custom.pid \
           --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
   fi
+fi
+## end if from "check needed files"
 fi

--- a/config/letsencrypt/letsrenew.sh
+++ b/config/letsencrypt/letsrenew.sh
@@ -41,7 +41,7 @@ onlinecheck () {
 }
 
 # needed files available for renewal or initial creation?
-if [ ! $((onlinecheck)) == 0 ] ||
+if [ $((onlinecheck)) != 0 ] ||
    [ ! -f "/config/letsencrypt/domain.csr" ] ||
    [ $(stat -c %s /config/letsencrypt/domain.csr) -eq 0 ] ||
    [ ! -f "/config/letsencrypt/domain.key" ] ||

--- a/config/letsencrypt/letsrenew.sh
+++ b/config/letsencrypt/letsrenew.sh
@@ -4,6 +4,10 @@
 #checks for needed files to continue
 #does nothing if no domain-registration is prepared from wizard
 
+#feature request
+#for renewal, custom lighttps must run on port 80
+#if not, move ports, renew, and switch back to previous ports
+
 # hosts to check for online status
 v4iphost='8.8.8.8'
 v4dnshost='www.google.com'

--- a/config/scripts/post-config.d/lighttpd_custom.sh
+++ b/config/scripts/post-config.d/lighttpd_custom.sh
@@ -1,24 +1,71 @@
-#!/bin/sh
+#!/bin/bash
+#letsrenew.sh
+#checks online state to continue
+#checks for needed files to continue
+#does nothing if no domain-registration is prepared from wizard
 
-# create missing log-directory if needed
-if [ ! -d "/var/log/lighttpd_custom" ]; then
-  mkdir /var/log/lighttpd_custom
-  chown www-data:www-data /var/log/lighttpd_custom
-fi
+# hosts to check for online status
+v4iphost='8.8.8.8'
+v4dnshost='www.google.com'
+v6iphost='2001:4860:4860::8888'
+v6dnshost='www.google.com'
+# function to check if connectivity is given to download packages
+onlinecheck () {
+    ping="ping -c 1 -W 1 ";
+    ping6="ping6 -c 1 -W 1 ";
+    $ping $v4iphost > /dev/null
+    if [[ $? == 0 ]]; then
+        $ping6 $v6iphost > /dev/null
+        if [[ $? == 0 ]]; then
+            $ping6 $v6dnshost > /dev/null
+            if [[ $? == 0 ]]; then
+                return 0
+            else
+                return 1
+            fi
+        else
+            $ping $v4dnshost > /dev/null
+            if [[ $? == 0 ]]; then
+                return 0
+            else
+                return 1
+            fi
+        fi
+    else
+        return 1
+    fi
+}
 
-# re-establish monthly renewal if needed
-if [ ! -L /etc/cron.monthly/letsrenew.sh ]; then
-  ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
-fi
+# needed files available for renewal or initial creation?
+if [ ! $((onlinecheck)) == 0 ] ||
+   [ ! -f "/config/letsencrypt/domain.csr" ] ||
+   [ $(stat -c %s /config/letsencrypt/domain.csr) -eq 0 ] ||
+   [ ! -f "/config/letsencrypt/domain.key" ] ||
+   [ $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ] ||
+   [ ! -f "/config/letsencrypt/account.key" ] ||
+   [ $(stat -c %s /config/letsencrypt/account.key) -eq 0 ] ||
+   [ ! -d "/config/custom/www/.well-known/acme-challenge/" ]
+then
+  echo "error: offline, missing or empty files, or challenge-directory!"
+else
 
-# re-establish current certificate file, only of domain.key is not of zero file-size
-# original server.pem contains "BEGIN PRIVATE KEY", whereas LE-signed server.pem includes "BEGIN RSA PRIVATE KEY".
-# only renew server.pem file if needed and signature file is >0 bytes
-if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] && [ $(grep "BEGIN RSA PRIVATE KEY" /etc/lighttpd/server.pem | wc -l) -eq 0 ]
-  then
+# Opening up firewall on port 80
+CHAIN=$( iptables -L | awk '/^Chain WAN/ && /LOCAL/ {print $2;}' )
+iptables -I $CHAIN 1 -p tcp --dport 80 -j ACCEPT
+
+# Run renewal script
+python /config/letsencrypt/acme_tiny.py --account-key /config/letsencrypt/account.key --csr /config/letsencrypt/domain.csr --acme-dir /config/custom/www/.well-known/acme-challenge/ > /config/letsencrypt/signed.crt
+
+# Removing firewall rule added earlier
+iptables -D $CHAIN 1
+
+# Copying files to lighttpd directory on success only (file domain.key is not empty)
+if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] &&
+   [ -f "/config/letsencrypt/domain.key" ] && [ ! $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ]
+then
   cat /config/letsencrypt/signed.crt | tee /etc/lighttpd/server.pem
   cat /config/letsencrypt/domain.key | tee -a /etc/lighttpd/server.pem
- 
+
   # Restarting original lighttpd webserver for EdgeOS
   sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd.pid
   if [ -f "/var/run/lighttpd.pid" ]; then
@@ -28,17 +75,18 @@ if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencry
         --pidfile /var/run/lighttpd.pid \
         --exec /usr/sbin/lighttpd -- -f /etc/lighttpd/lighttpd.conf
   
-  # stop custom webserver if already running
-  sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd_custom.pid
-  if [ -f "/var/run/lighttpd_custom.pid" ]; then
-    rm /var/run/lighttpd_custom.pid
+  # Restart custom lighttpd webserver for custom scripts
+  # only if default webserver is not configured to run on port 80/443...
+  # CPO: improve: custom-server on port http-80, stock-server von https-443 should work as well!
+  if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 0 ] && [ $(grep "http-port 80" /config/config.boot | wc -l) -eq 0 ]; then
+    sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd_custom.pid
+    if [ -f "/var/run/lighttpd_custom.pid" ]; then
+      rm /var/run/lighttpd_custom.pid
+    fi
+    sudo /sbin/start-stop-daemon --start --quiet \
+          --pidfile /var/run/lighttpd_custom.pid \
+          --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
   fi
 fi
-
-# Start custom webserver
-# CPO: improve: custom-server on port http-80, stock-server von https-443 should work as well!
-if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 0 ] && [ $(grep "http-port 80" /config/config.boot | wc -l) -eq 0 ]; then
-  sudo /sbin/start-stop-daemon --start --quiet \
-        --pidfile /var/run/lighttpd_custom.pid \
-        --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
+## end if from "check needed files"
 fi

--- a/config/scripts/post-config.d/lighttpd_custom.sh
+++ b/config/scripts/post-config.d/lighttpd_custom.sh
@@ -1,71 +1,30 @@
-#!/bin/bash
-#letsrenew.sh
-#checks online state to continue
-#checks for needed files to continue
-#does nothing if no domain-registration is prepared from wizard
+#!/bin/sh
+#post-config.d/lighttpd_custom.sh
+#re-establishes server.pem with certificate (if possible or needed)
+#re-establishes renew-cronjob (if missing)
+#starts custom lighttpd
 
-# hosts to check for online status
-v4iphost='8.8.8.8'
-v4dnshost='www.google.com'
-v6iphost='2001:4860:4860::8888'
-v6dnshost='www.google.com'
-# function to check if connectivity is given to download packages
-onlinecheck () {
-    ping="ping -c 1 -W 1 ";
-    ping6="ping6 -c 1 -W 1 ";
-    $ping $v4iphost > /dev/null
-    if [[ $? == 0 ]]; then
-        $ping6 $v6iphost > /dev/null
-        if [[ $? == 0 ]]; then
-            $ping6 $v6dnshost > /dev/null
-            if [[ $? == 0 ]]; then
-                return 0
-            else
-                return 1
-            fi
-        else
-            $ping $v4dnshost > /dev/null
-            if [[ $? == 0 ]]; then
-                return 0
-            else
-                return 1
-            fi
-        fi
-    else
-        return 1
-    fi
-}
+# create missing log-directory if needed
+if [ ! -d "/var/log/lighttpd_custom" ]; then
+  mkdir /var/log/lighttpd_custom
+  chown www-data:www-data /var/log/lighttpd_custom
+fi
 
-# needed files available for renewal or initial creation?
-if [ ! $((onlinecheck)) == 0 ] ||
-   [ ! -f "/config/letsencrypt/domain.csr" ] ||
-   [ $(stat -c %s /config/letsencrypt/domain.csr) -eq 0 ] ||
-   [ ! -f "/config/letsencrypt/domain.key" ] ||
-   [ $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ] ||
-   [ ! -f "/config/letsencrypt/account.key" ] ||
-   [ $(stat -c %s /config/letsencrypt/account.key) -eq 0 ] ||
-   [ ! -d "/config/custom/www/.well-known/acme-challenge/" ]
-then
-  echo "error: offline, missing or empty files, or challenge-directory!"
-else
+# re-establish monthly renewal if needed
+if [ ! -L /etc/cron.monthly/letsrenew.sh ]; then
+  ln -sf /config/letsencrypt/letsrenew.sh /etc/cron.monthly/letsrenew.sh
+fi
 
-# Opening up firewall on port 80
-CHAIN=$( iptables -L | awk '/^Chain WAN/ && /LOCAL/ {print $2;}' )
-iptables -I $CHAIN 1 -p tcp --dport 80 -j ACCEPT
-
-# Run renewal script
-python /config/letsencrypt/acme_tiny.py --account-key /config/letsencrypt/account.key --csr /config/letsencrypt/domain.csr --acme-dir /config/custom/www/.well-known/acme-challenge/ > /config/letsencrypt/signed.crt
-
-# Removing firewall rule added earlier
-iptables -D $CHAIN 1
-
-# Copying files to lighttpd directory on success only (file domain.key is not empty)
-if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] &&
-   [ -f "/config/letsencrypt/domain.key" ] && [ ! $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ]
-then
+# re-establish current certificate file, only of domain.key is not of zero file-size
+# original server.pem contains "BEGIN PRIVATE KEY", whereas LE-signed server.pem includes "BEGIN RSA PRIVATE KEY".
+# only renew server.pem file if needed and signature file is >0 bytes
+if [ -f "/config/letsencrypt/signed.crt" ] && [ ! $(stat -c %s /config/letsencrypt/signed.crt) -eq 0 ] && 
+   [ -f "/config/letsencrypt/domain.key" ] && [ ! $(stat -c %s /config/letsencrypt/domain.key) -eq 0 ] &&
+   [ $(grep "BEGIN RSA PRIVATE KEY" /etc/lighttpd/server.pem | wc -l) -eq 0 ]
+  then
   cat /config/letsencrypt/signed.crt | tee /etc/lighttpd/server.pem
   cat /config/letsencrypt/domain.key | tee -a /etc/lighttpd/server.pem
-
+ 
   # Restarting original lighttpd webserver for EdgeOS
   sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd.pid
   if [ -f "/var/run/lighttpd.pid" ]; then
@@ -75,18 +34,17 @@ then
         --pidfile /var/run/lighttpd.pid \
         --exec /usr/sbin/lighttpd -- -f /etc/lighttpd/lighttpd.conf
   
-  # Restart custom lighttpd webserver for custom scripts
-  # only if default webserver is not configured to run on port 80/443...
-  # CPO: improve: custom-server on port http-80, stock-server von https-443 should work as well!
-  if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 0 ] && [ $(grep "http-port 80" /config/config.boot | wc -l) -eq 0 ]; then
-    sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd_custom.pid
-    if [ -f "/var/run/lighttpd_custom.pid" ]; then
-      rm /var/run/lighttpd_custom.pid
-    fi
-    sudo /sbin/start-stop-daemon --start --quiet \
-          --pidfile /var/run/lighttpd_custom.pid \
-          --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
+  # stop custom webserver if already running
+  sudo /sbin/start-stop-daemon --stop --pidfile /var/run/lighttpd_custom.pid
+  if [ -f "/var/run/lighttpd_custom.pid" ]; then
+    rm /var/run/lighttpd_custom.pid
   fi
 fi
-## end if from "check needed files"
+
+# Start custom webserver
+# CPO: improve: custom-server on port http-80, stock-server von https-443 should work as well!
+if [ $(grep "https-port 443" /config/config.boot | wc -l) -eq 0 ] && [ $(grep "http-port 80" /config/config.boot | wc -l) -eq 0 ]; then
+  sudo /sbin/start-stop-daemon --start --quiet \
+        --pidfile /var/run/lighttpd_custom.pid \
+        --exec /usr/sbin/lighttpd -- -f /config/custom/lighttpd/lighttpd_custom.conf
 fi


### PR DESCRIPTION
Removed automatic registration and renewal-process (what was introduced in v4.0).
Installation will maintain an existing key and signature and will keep server.pem signed.
Initial registration of FQDN and initial certificate renewal will NOT be executed: this will be triggered and executed from ER-wizard-0xFF-WSLE starting this version (v4.1).
